### PR TITLE
Fix Tailwind config and refactor dashboard UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.49",
-    "shadcn-ui": "^0.10.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
     "vite": "^5.4.11"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,45 @@
+import { useMemo, useState } from "react";
 import "./index.css";
-import Sidebar from "./components/layout/Sidebar";
 import Dashboard from "./components/layout/Dashboard";
+import Sidebar, { NAV_ITEMS } from "./components/layout/Sidebar";
+
+const DASHBOARD_STATS = {
+  home: [
+    { title: "Quick Tips", value: "Get started", change: "Review the onboarding checklist" },
+    { title: "Team Invites", value: "2 pending" },
+    { title: "Notifications", value: "5 unread" },
+  ],
+  dashboard: [
+    { title: "Active Users", value: "1,230", change: "+5.2% vs last week" },
+    { title: "Revenue", value: "$87.4K", change: "+12.4% vs target" },
+    { title: "Support Tickets", value: "32", change: "8 resolved in the last hour" },
+  ],
+  settings: [
+    { title: "Profile Completion", value: "82%", change: "Add billing details to finish" },
+    { title: "Team Roles", value: "4 assigned" },
+    { title: "API Keys", value: "3 active", change: "Rotate keys every 90 days" },
+  ],
+};
 
 export default function App() {
+  const [activeItem, setActiveItem] = useState("dashboard");
+
+  const currentNav = useMemo(
+    () => NAV_ITEMS.find((item) => item.key === activeItem),
+    [activeItem],
+  );
+
+  const pageTitle = currentNav?.label ?? "Dashboard";
+  const stats = DASHBOARD_STATS[activeItem] ?? DASHBOARD_STATS.dashboard;
+
   return (
     <div className="flex min-h-screen">
-      <Sidebar />
+      <Sidebar activeItem={activeItem} onSelect={(item) => setActiveItem(item.key)} />
       <main className="flex-1">
         <header className="border-b p-4">
-          <h1 className="text-2xl font-semibold text-primary">Dashboard</h1>
+          <h1 className="text-2xl font-semibold text-primary">{pageTitle}</h1>
         </header>
-        <Dashboard />
+        <Dashboard stats={stats} />
       </main>
     </div>
   );

--- a/src/components/layout/Dashboard.jsx
+++ b/src/components/layout/Dashboard.jsx
@@ -20,9 +20,7 @@ export default function Dashboard({ stats = [] }) {
           </CardHeader>
           <CardContent className="space-y-1">
             <p className="text-3xl font-semibold tracking-tight text-foreground">{value}</p>
-            {change ? (
-              <p className="text-xs text-muted-foreground">{change}</p>
-            ) : null}
+            {change && <p className="text-xs text-muted-foreground">{change}</p>}
           </CardContent>
         </Card>
       ))}

--- a/src/components/layout/Dashboard.jsx
+++ b/src/components/layout/Dashboard.jsx
@@ -1,26 +1,31 @@
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 
-export default function Dashboard() {
+export default function Dashboard({ stats = [] }) {
+  if (stats.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6 text-sm text-muted-foreground">
+        No metrics available for this view.
+      </div>
+    );
+  }
+
   return (
-    <div className="p-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3 w-full">
-      <Card>
-        <CardHeader>
-          <CardTitle>Stat A</CardTitle>
-        </CardHeader>
-        <CardContent>123</CardContent>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>Stat B</CardTitle>
-        </CardHeader>
-        <CardContent>456</CardContent>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>Stat C</CardTitle>
-        </CardHeader>
-        <CardContent>789</CardContent>
-      </Card>
+    <div className="w-full grid gap-4 p-6 md:grid-cols-2 lg:grid-cols-3">
+      {stats.map(({ title, value, change }) => (
+        <Card key={title}>
+          <CardHeader>
+            <CardTitle className="text-base font-medium text-muted-foreground">
+              {title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <p className="text-3xl font-semibold tracking-tight text-foreground">{value}</p>
+            {change ? (
+              <p className="text-xs text-muted-foreground">{change}</p>
+            ) : null}
+          </CardContent>
+        </Card>
+      ))}
     </div>
   );
 }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,25 +1,46 @@
 import { Home, LayoutGrid, Settings } from "lucide-react";
-import { Separator } from "../ui/separator";
 import { Button } from "../ui/button";
+import {
+  Sidebar as SidebarPrimitive,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+} from "../ui/sidebar";
 
-export default function Sidebar() {
+export const NAV_ITEMS = [
+  { key: "home", label: "Home", icon: Home },
+  { key: "dashboard", label: "Dashboard", icon: LayoutGrid },
+  { key: "settings", label: "Settings", icon: Settings },
+];
+
+export default function Sidebar({ activeItem, onSelect }) {
   return (
-    <aside className="h-screen w-64 border-r p-4 flex flex-col gap-2">
-      <div className="text-xl font-semibold text-primary">Shadcn Dashboard</div>
-      <Separator />
-      <nav className="flex-1 mt-2 space-y-1">
-        <Button variant="ghost" className="w-full justify-start gap-2">
-          <Home size={16} /> Home
-        </Button>
-        <Button variant="ghost" className="w-full justify-start gap-2">
-          <LayoutGrid size={16} /> Dashboard
-        </Button>
-        <Button variant="ghost" className="w-full justify-start gap-2">
-          <Settings size={16} /> Settings
-        </Button>
-      </nav>
-      <Separator />
-      <div className="text-xs text-muted-foreground">v0.1.0</div>
-    </aside>
+    <SidebarPrimitive className="h-screen">
+      <SidebarHeader>
+        <div className="text-xl font-semibold text-primary">Shadcn Dashboard</div>
+      </SidebarHeader>
+      <SidebarContent>
+        <nav className="space-y-1">
+          {NAV_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const isActive = activeItem === item.key;
+
+            return (
+              <Button
+                key={item.key}
+                type="button"
+                variant={isActive ? "secondary" : "ghost"}
+                className="w-full justify-start gap-2"
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => onSelect?.(item)}
+              >
+                <Icon size={16} aria-hidden="true" /> {item.label}
+              </Button>
+            );
+          })}
+        </nav>
+      </SidebarContent>
+      <SidebarFooter>v0.1.0</SidebarFooter>
+    </SidebarPrimitive>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,14 @@
-module.exports = {
+import animate from "tailwindcss-animate";
+
+/** @type {import('tailwindcss').Config} */
+const config = {
   darkMode: ["class"],
-  content: [
-    "./index.html",
-    "./src/**/*.{js,jsx,ts,tsx}",
-    "./src/components/**/*.{js,jsx,ts,tsx}",
-  ],
+  content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
-    container: { center: true, padding: "2rem" },
+    container: {
+      center: true,
+      padding: "2rem",
+    },
     extend: {
       colors: {
         border: "hsl(var(--border))",
@@ -15,11 +17,11 @@ module.exports = {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         primary: {
-          DEFAULT: "#2563eb", // blue-600
+          DEFAULT: "#2563eb",
           foreground: "#ffffff",
         },
         secondary: {
-          DEFAULT: "#1d4ed8", // blue-700
+          DEFAULT: "#1d4ed8",
           foreground: "#ffffff",
         },
       },
@@ -29,8 +31,14 @@ module.exports = {
         sm: "calc(var(--radius) - 4px)",
       },
       keyframes: {
-        "accordion-down": { from: { height: 0 }, to: { height: "var(--radix-accordion-content-height)" } },
-        "accordion-up": { from: { height: "var(--radix-accordion-content-height)" }, to: { height: 0 } },
+        "accordion-down": {
+          from: { height: 0 },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: 0 },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -38,5 +46,7 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 };
+
+export default config;

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,7 +1,9 @@
 export default {
-  async fetch(request, env, ctx) {
-    return env.ASSETS
-      ? env.ASSETS.fetch(request)
-      : new Response("Assets binding missing", { status: 500 });
+  async fetch(request, env) {
+    if (!env.ASSETS) {
+      return Response.json({ error: "Assets binding missing" }, { status: 500 });
+    }
+
+    return env.ASSETS.fetch(request);
   },
 };


### PR DESCRIPTION
## Summary
- convert the Tailwind configuration to ESM, simplify the content paths, and load the animate plugin without CommonJS
- remove the nonexistent `shadcn-ui` package from devDependencies
- refactor the sidebar to use shadcn/ui primitives with data-driven navigation and drive dashboard stats and page titles from shared state
- return structured JSON from the worker when the ASSETS binding is missing

## Testing
- npm run build *(fails: local environment is missing the Vite binary and npm install cannot complete due to an npm error)*

------
https://chatgpt.com/codex/tasks/task_e_68e28171fc38832e82dde20e4627caef